### PR TITLE
Make API /verifywithemail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'io.jsonwebtoken:jjwt-api:0.10.7'
+    runtime 'io.jsonwebtoken:jjwt-impl:0.10.7'
+    runtime 'io.jsonwebtoken:jjwt-jackson:0.10.7'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    compile group: 'org.json', name: 'json', version: '20160810'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'io.jsonwebtoken:jjwt-api:0.10.7'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compile group: 'org.json', name: 'json', version: '20160810'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/example/darnerdanuh/DarnerDanUhApplication.java
+++ b/src/main/java/com/example/darnerdanuh/DarnerDanUhApplication.java
@@ -2,12 +2,20 @@ package com.example.darnerdanuh;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 public class DarnerDanUhApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(DarnerDanUhApplication.class, args);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
     }
 
 }

--- a/src/main/java/com/example/darnerdanuh/DarnerDanUhApplication.java
+++ b/src/main/java/com/example/darnerdanuh/DarnerDanUhApplication.java
@@ -14,7 +14,7 @@ public class DarnerDanUhApplication {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder(){
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 

--- a/src/main/java/com/example/darnerdanuh/config/EmailConfig.java
+++ b/src/main/java/com/example/darnerdanuh/config/EmailConfig.java
@@ -1,0 +1,58 @@
+package com.example.darnerdanuh.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@PropertySource("classpath:mail.properties")
+public class EmailConfig {
+
+    @Value("${mail.smtp.port}")
+    private int port;
+    @Value("${mail.smtp.socketFactory.port}")
+    private int socketPort;
+    @Value("${mail.smtp.auth}")
+    private boolean auth;
+    @Value("${mail.smtp.starttls.enable}")
+    private boolean starttls;
+    @Value("${mail.smtp.starttls.required}")
+    private boolean startlls_required;
+    @Value("${mail.smtp.socketFactory.fallback}")
+    private boolean fallback;
+    @Value("${AdminMail.id}")
+    private String mailId;
+    @Value("${AdminMail.password}")
+    private String mailPassword;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost("smtp.gmail.com");
+        javaMailSender.setUsername(mailId);
+        javaMailSender.setPassword(mailPassword);
+        javaMailSender.setPort(port);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        javaMailSender.setDefaultEncoding("UTF-8");
+        return javaMailSender;
+    }
+    private Properties getMailProperties()
+    {
+        System.out.println(mailId + mailPassword);
+        Properties pt = new Properties();
+        pt.put("mail.smtp.socketFactory.port", socketPort);
+        pt.put("mail.smtp.auth", auth);
+        pt.put("mail.smtp.starttls.enable", starttls);
+        pt.put("mail.smtp.starttls.required", startlls_required);
+        pt.put("mail.smtp.socketFactory.fallback",fallback);
+        pt.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+        return pt;
+    }
+
+
+}

--- a/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationEntryPoint.java
@@ -1,4 +1,5 @@
 package com.example.darnerdanuh.config;
+
 import org.json.JSONObject;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;

--- a/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package com.example.darnerdanuh.config;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException e) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "UnAuthorized");
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,5 @@
 package com.example.darnerdanuh.config;
-
+import org.json.JSONObject;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -8,6 +8,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.PrintWriter;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
@@ -15,6 +16,14 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException e) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "UnAuthorized");
+        //response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "UnAuthorized");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=utf-8");
+        JSONObject json = new JSONObject();
+        String message = "UnAuthorized";
+        json.put("message", message);
+
+        PrintWriter out = response.getWriter();
+        out.print(json);
     }
 }

--- a/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationProvider.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationProvider.java
@@ -1,0 +1,42 @@
+package com.example.darnerdanuh.config;
+
+import com.example.darnerdanuh.domain.member.Member;
+import com.example.darnerdanuh.domain.member.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String userId = authentication.getName();
+        String password = authentication.getCredentials().toString();
+
+        Member member = memberRepository.findByUserId(userId).orElseThrow(() -> new UsernameNotFoundException(userId));
+
+        if(passwordEncoder.matches(member.getPassword(), password)) {
+            throw new BadCredentialsException("UnAuthorized");
+        }
+
+        return new UsernamePasswordAuthenticationToken(userId, password);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationProvider.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtAuthenticationProvider.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
         Member member = memberRepository.findByUserId(userId).orElseThrow(() -> new UsernameNotFoundException(userId));
 
-        if(passwordEncoder.matches(member.getPassword(), password)) {
+        if (passwordEncoder.matches(member.getPassword(), password)) {
             throw new BadCredentialsException("UnAuthorized");
         }
 

--- a/src/main/java/com/example/darnerdanuh/config/JwtRequest.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtRequest.java
@@ -1,0 +1,10 @@
+package com.example.darnerdanuh.config;
+
+import lombok.Data;
+
+@Data
+public class JwtRequest {
+
+    private String userId;
+    private String password;
+}

--- a/src/main/java/com/example/darnerdanuh/config/JwtRequestFilter.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtRequestFilter.java
@@ -1,0 +1,79 @@
+package com.example.darnerdanuh.config;
+
+import com.example.darnerdanuh.service.JwtUserDetailsService;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtUserDetailsService jwtUserDetailsService;
+
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    private static final List<String> EXCLUDE_URL =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            "/signup",
+                            "/login"
+                    )
+            );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException{
+        final String requestTokenHeader = request.getHeader("Authorization");
+
+        String username = null;
+        String jwtToken = null;
+
+        if(requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")){
+            jwtToken = requestTokenHeader.substring(7);
+            try {
+                username = jwtTokenUtil.getUsernameFromToken(jwtToken);
+            }catch (IllegalArgumentException e){
+                System.out.println("Unable to get JWT Token");
+            }catch (ExpiredJwtException e){
+                System.out.println("JWT Token has expired");
+            }
+        }else{
+            logger.warn("JWT Token does not begin with Bearer String");
+        }
+
+        if(username != null && SecurityContextHolder.getContext().getAuthentication() == null){
+            UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(username);
+
+            if(jwtTokenUtil.validateToken(jwtToken, userDetails)) {
+                UsernamePasswordAuthenticationToken authenticationToken =
+                        new UsernamePasswordAuthenticationToken(userDetails, null ,userDetails.getAuthorities());
+
+                authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return EXCLUDE_URL.stream().anyMatch(exclude -> exclude.equalsIgnoreCase(request.getServletPath()));
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/config/JwtRequestFilter.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtRequestFilter.java
@@ -39,31 +39,31 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException{
+                                    FilterChain filterChain) throws ServletException, IOException {
         final String requestTokenHeader = request.getHeader("Authorization");
 
         String username = null;
         String jwtToken = null;
 
-        if(requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")){
+        if (requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")) {
             jwtToken = requestTokenHeader.substring(7);
             try {
                 username = jwtTokenUtil.getUsernameFromToken(jwtToken);
-            }catch (IllegalArgumentException e){
+            } catch (IllegalArgumentException e) {
                 System.out.println("Unable to get JWT Token");
-            }catch (ExpiredJwtException e){
+            } catch (ExpiredJwtException e) {
                 System.out.println("JWT Token has expired");
             }
-        }else{
+        } else {
             logger.warn("JWT Token does not begin with Bearer String");
         }
 
-        if(username != null && SecurityContextHolder.getContext().getAuthentication() == null){
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(username);
 
-            if(jwtTokenUtil.validateToken(jwtToken, userDetails)) {
+            if (jwtTokenUtil.validateToken(jwtToken, userDetails)) {
                 UsernamePasswordAuthenticationToken authenticationToken =
-                        new UsernamePasswordAuthenticationToken(userDetails, null ,userDetails.getAuthorities());
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
                 authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authenticationToken);

--- a/src/main/java/com/example/darnerdanuh/config/JwtResponse.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtResponse.java
@@ -1,0 +1,11 @@
+package com.example.darnerdanuh.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class JwtResponse {
+
+    private String token;
+}

--- a/src/main/java/com/example/darnerdanuh/config/JwtTokenUtil.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtTokenUtil.java
@@ -1,0 +1,66 @@
+package com.example.darnerdanuh.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class JwtTokenUtil {
+
+    private static final String secret = "fsfhvbsknjvlsdni47y45349287394ndw849238rkwjenfkjsdnow84u938u9283749283ujlwnfvnshfxcjxnciue2893u203u2o3irjo23irjwekmfsdretrtertrhrthrterthr3wthwrthtthtrthtrtgrrgrrthrgbggndbewfgbdgdfngrtrhfgwtgr";
+
+    public static final long JWT_TOKEN_VALIDITY = 5 * 60 * 60;
+
+    public String getUsernameFromToken(String token){
+        return getClaimFromToken(token, Claims::getId);
+    }
+
+    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = getAllClaimsFromToken(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims getAllClaimsFromToken(String token) {
+        return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+    }
+
+    private Boolean isTokenExpired(String token) {
+        final Date expiration = getExpirationDateFromToken(token);
+        return expiration.before(new Date());
+    }
+
+    public Date getExpirationDateFromToken(String token) {
+        return getClaimFromToken(token, Claims::getExpiration);
+    }
+
+    public String generateToken(String id) {
+        return generateToken(id, new HashMap<>());
+    }
+
+    public String generateToken(String id, Map<String, Object> claims) {
+        return doGenerateToken(id, claims);
+    }
+
+    private String doGenerateToken(String id, Map<String, Object> claims) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setId(id)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY * 1000))
+                .signWith(SignatureAlgorithm.HS512, secret)
+                .compact();
+    }
+
+    public Boolean validateToken(String token, UserDetails userDetails){
+        final String username = getUsernameFromToken(token);
+        return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+    }
+
+}

--- a/src/main/java/com/example/darnerdanuh/config/JwtTokenUtil.java
+++ b/src/main/java/com/example/darnerdanuh/config/JwtTokenUtil.java
@@ -18,7 +18,7 @@ public class JwtTokenUtil {
 
     public static final long JWT_TOKEN_VALIDITY = 5 * 60 * 60;
 
-    public String getUsernameFromToken(String token){
+    public String getUsernameFromToken(String token) {
         return getClaimFromToken(token, Claims::getId);
     }
 
@@ -58,7 +58,7 @@ public class JwtTokenUtil {
                 .compact();
     }
 
-    public Boolean validateToken(String token, UserDetails userDetails){
+    public Boolean validateToken(String token, UserDetails userDetails) {
         final String username = getUsernameFromToken(token);
         return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
     }

--- a/src/main/java/com/example/darnerdanuh/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/darnerdanuh/config/WebSecurityConfig.java
@@ -1,0 +1,60 @@
+package com.example.darnerdanuh.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private AuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Autowired
+    private UserDetailsService jwtUserDetailsService;
+
+    @Autowired
+    private JwtRequestFilter jwtRequestFilter;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+
+        auth.jdbcAuthentication().dataSource(dataSource);
+        auth
+                .userDetailsService(jwtUserDetailsService)
+                .passwordEncoder(passwordEncoder);
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .authorizeRequests().antMatchers("/login", "/signup").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/controller/JwtAuthenticationController.java
+++ b/src/main/java/com/example/darnerdanuh/controller/JwtAuthenticationController.java
@@ -1,0 +1,32 @@
+package com.example.darnerdanuh.controller;
+
+import com.example.darnerdanuh.config.JwtRequest;
+import com.example.darnerdanuh.config.JwtResponse;
+import com.example.darnerdanuh.config.JwtTokenUtil;
+import com.example.darnerdanuh.domain.member.Member;
+import com.example.darnerdanuh.service.JwtUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@CrossOrigin
+public class JwtAuthenticationController {
+
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private JwtUserDetailsService userDetailService;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> createAuthenticationToken(@RequestBody JwtRequest authenticationRequest) throws Exception {
+        final Member member = userDetailService.authenticateByUserIdAndPassword
+                (authenticationRequest.getUserId(), authenticationRequest.getPassword());
+        final String token = jwtTokenUtil.generateToken(member.getUserId());
+        return ResponseEntity.ok(new JwtResponse(token));
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/controller/JwtAuthenticationController.java
+++ b/src/main/java/com/example/darnerdanuh/controller/JwtAuthenticationController.java
@@ -4,6 +4,7 @@ import com.example.darnerdanuh.config.JwtRequest;
 import com.example.darnerdanuh.config.JwtResponse;
 import com.example.darnerdanuh.config.JwtTokenUtil;
 import com.example.darnerdanuh.domain.member.Member;
+import com.example.darnerdanuh.domain.member.MemberDto;
 import com.example.darnerdanuh.service.JwtUserDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -22,11 +23,14 @@ public class JwtAuthenticationController {
     @Autowired
     private JwtUserDetailsService userDetailService;
 
+    MemberDto memberDto;
+
     @PostMapping("/login")
     public ResponseEntity<?> createAuthenticationToken(@RequestBody JwtRequest authenticationRequest) throws Exception {
         final Member member = userDetailService.authenticateByUserIdAndPassword
                 (authenticationRequest.getUserId(), authenticationRequest.getPassword());
         final String token = jwtTokenUtil.generateToken(member.getUserId());
+
         return ResponseEntity.ok(new JwtResponse(token));
     }
 }

--- a/src/main/java/com/example/darnerdanuh/controller/MemberController.java
+++ b/src/main/java/com/example/darnerdanuh/controller/MemberController.java
@@ -5,7 +5,6 @@ import com.example.darnerdanuh.domain.member.Member;
 import com.example.darnerdanuh.domain.member.MemberDto;
 import com.example.darnerdanuh.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.json.JSONObject;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,7 +18,7 @@ public class MemberController {
     final PasswordEncoder encode;
 
     @PostMapping("/signup")
-    public ResponseJson saveMember(@RequestBody MemberDto memberDto){
+    public ResponseJson saveMember(@RequestBody MemberDto memberDto) {
         memberRepository.save(Member.createMember(memberDto.getUserId(),
                 memberDto.getName(), memberDto.getEmail(),
                 encode.encode(memberDto.getPassword())));

--- a/src/main/java/com/example/darnerdanuh/controller/MemberController.java
+++ b/src/main/java/com/example/darnerdanuh/controller/MemberController.java
@@ -1,14 +1,12 @@
 package com.example.darnerdanuh.controller;
 
 import com.example.darnerdanuh.domain.ResponseJson;
-import com.example.darnerdanuh.domain.member.Member;
 import com.example.darnerdanuh.domain.member.MemberDto;
-import com.example.darnerdanuh.domain.member.MemberRepository;
-import com.example.darnerdanuh.service.EmailService;
+import com.example.darnerdanuh.domain.member.VerifyInfo;
+import com.example.darnerdanuh.service.SignUpService;
+import com.example.darnerdanuh.service.VerifyCodeService;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,23 +14,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
+    private final VerifyCodeService verifyCodeService;
 
-    private final MemberRepository memberRepository;
-    private final PasswordEncoder encode;
+    private final SignUpService signUpService;
 
-    private final EmailService service;
-
-    @SneakyThrows
     @PostMapping("/signup")
     public ResponseJson saveMember(@RequestBody MemberDto memberDto) {
-        memberRepository.save(Member.createMember(memberDto.getUserId(),
-                memberDto.getName(), memberDto.getEmail(),
-                encode.encode(memberDto.getPassword())));
-        service.sendSimpleMessage(memberDto.getEmail());
+        return signUpService.signUp(memberDto);
+    }
 
-        ResponseJson json = new ResponseJson();
-        json.setMessage("success");
-
-        return json;
+    @PostMapping("/verifywithemail")
+    public ResponseJson verifyCode(@RequestBody VerifyInfo verifyInfo){
+        return verifyCodeService.setVerifyCode(verifyInfo);
     }
 }

--- a/src/main/java/com/example/darnerdanuh/controller/MemberController.java
+++ b/src/main/java/com/example/darnerdanuh/controller/MemberController.java
@@ -4,7 +4,10 @@ import com.example.darnerdanuh.domain.ResponseJson;
 import com.example.darnerdanuh.domain.member.Member;
 import com.example.darnerdanuh.domain.member.MemberDto;
 import com.example.darnerdanuh.domain.member.MemberRepository;
+import com.example.darnerdanuh.service.EmailService;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,14 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
 
-    final MemberRepository memberRepository;
-    final PasswordEncoder encode;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder encode;
 
+    private final EmailService service;
+
+    @SneakyThrows
     @PostMapping("/signup")
     public ResponseJson saveMember(@RequestBody MemberDto memberDto) {
         memberRepository.save(Member.createMember(memberDto.getUserId(),
                 memberDto.getName(), memberDto.getEmail(),
                 encode.encode(memberDto.getPassword())));
+        service.sendSimpleMessage(memberDto.getEmail());
 
         ResponseJson json = new ResponseJson();
         json.setMessage("success");

--- a/src/main/java/com/example/darnerdanuh/controller/MemberController.java
+++ b/src/main/java/com/example/darnerdanuh/controller/MemberController.java
@@ -1,0 +1,27 @@
+package com.example.darnerdanuh.controller;
+
+import com.example.darnerdanuh.domain.member.Member;
+import com.example.darnerdanuh.domain.member.MemberDto;
+import com.example.darnerdanuh.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    final MemberRepository memberRepository;
+    final PasswordEncoder encode;
+
+    @PostMapping("/signup")
+    public String saveMember(@RequestBody MemberDto memberDto){
+        memberRepository.save(Member.createMember(memberDto.getUserId(),
+                memberDto.getName(), memberDto.getEmail(),
+                encode.encode(memberDto.getPassword())));
+
+        return "success";
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/controller/MemberController.java
+++ b/src/main/java/com/example/darnerdanuh/controller/MemberController.java
@@ -1,9 +1,11 @@
 package com.example.darnerdanuh.controller;
 
+import com.example.darnerdanuh.domain.ResponseJson;
 import com.example.darnerdanuh.domain.member.Member;
 import com.example.darnerdanuh.domain.member.MemberDto;
 import com.example.darnerdanuh.domain.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.json.JSONObject;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,11 +19,14 @@ public class MemberController {
     final PasswordEncoder encode;
 
     @PostMapping("/signup")
-    public String saveMember(@RequestBody MemberDto memberDto){
+    public ResponseJson saveMember(@RequestBody MemberDto memberDto){
         memberRepository.save(Member.createMember(memberDto.getUserId(),
                 memberDto.getName(), memberDto.getEmail(),
                 encode.encode(memberDto.getPassword())));
 
-        return "success";
+        ResponseJson json = new ResponseJson();
+        json.setMessage("success");
+
+        return json;
     }
 }

--- a/src/main/java/com/example/darnerdanuh/domain/ResponseJson.java
+++ b/src/main/java/com/example/darnerdanuh/domain/ResponseJson.java
@@ -1,0 +1,11 @@
+package com.example.darnerdanuh.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ResponseJson {
+
+    private String message;
+}

--- a/src/main/java/com/example/darnerdanuh/domain/member/Member.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/Member.java
@@ -1,0 +1,39 @@
+package com.example.darnerdanuh.domain.member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@Entity(name="member")
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long user_num;
+
+    @Column(unique = true, name = "user_id")
+    private String userId;
+
+    @Column
+    private String name;
+    private String email;
+    private String password;
+
+    public Member(String userId, String name, String email, String password){
+        this.userId = userId;
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
+
+    public static Member createMember(String userId, String name, String email, String password){
+        return new Member(userId, name, email, password);
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/domain/member/Member.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/Member.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 
 import javax.persistence.*;
 
-@Entity(name="member")
+@Entity(name = "member")
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,14 +26,14 @@ public class Member {
     private String email;
     private String password;
 
-    public Member(String userId, String name, String email, String password){
+    public Member(String userId, String name, String email, String password) {
         this.userId = userId;
         this.name = name;
         this.email = email;
         this.password = password;
     }
 
-    public static Member createMember(String userId, String name, String email, String password){
+    public static Member createMember(String userId, String name, String email, String password) {
         return new Member(userId, name, email, password);
     }
 }

--- a/src/main/java/com/example/darnerdanuh/domain/member/Member.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/Member.java
@@ -1,15 +1,13 @@
 package com.example.darnerdanuh.domain.member;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Entity(name = "member")
 @Getter
-@ToString
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
@@ -26,15 +24,17 @@ public class Member {
     private String email;
     private String password;
     private boolean permitted = false;
+    private String verifyCode;
 
-    public Member(String userId, String name, String email, String password) {
-        this.userId = userId;
-        this.name = name;
-        this.email = email;
-        this.password = password;
+    public Member verifyCodeUpdate(String verifyCode) {
+        this.verifyCode = verifyCode;
+
+        return this;
     }
 
-    public static Member createMember(String userId, String name, String email, String password) {
-        return new Member(userId, name, email, password);
+    public Member permittedUpdate(boolean permitted) {
+        this.permitted = permitted;
+
+        return this;
     }
 }

--- a/src/main/java/com/example/darnerdanuh/domain/member/Member.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/Member.java
@@ -25,6 +25,7 @@ public class Member {
     private String name;
     private String email;
     private String password;
+    private boolean permitted = false;
 
     public Member(String userId, String name, String email, String password) {
         this.userId = userId;

--- a/src/main/java/com/example/darnerdanuh/domain/member/MemberDto.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/MemberDto.java
@@ -8,4 +8,5 @@ public class MemberDto {
     private String name;
     private String email;
     private String password;
+    private boolean permitted;
 }

--- a/src/main/java/com/example/darnerdanuh/domain/member/MemberDto.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/MemberDto.java
@@ -1,0 +1,11 @@
+package com.example.darnerdanuh.domain.member;
+
+import lombok.Data;
+
+@Data
+public class MemberDto {
+    private String userId;
+    private String name;
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/darnerdanuh/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.example.darnerdanuh.domain.member;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends CrudRepository<Member, Long> {
+    Optional<Member> findByUserId(String userId);
+}

--- a/src/main/java/com/example/darnerdanuh/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/MemberRepository.java
@@ -1,9 +1,13 @@
 package com.example.darnerdanuh.domain.member;
 
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+
+@Repository
 public interface MemberRepository extends CrudRepository<Member, Long> {
     Optional<Member> findByUserId(String userId);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/example/darnerdanuh/domain/member/Role.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/Role.java
@@ -1,0 +1,14 @@
+package com.example.darnerdanuh.domain.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Role {
+
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private String value;
+}

--- a/src/main/java/com/example/darnerdanuh/domain/member/VerifyInfo.java
+++ b/src/main/java/com/example/darnerdanuh/domain/member/VerifyInfo.java
@@ -1,0 +1,14 @@
+package com.example.darnerdanuh.domain.member;
+
+import lombok.Data;
+
+@Data
+public class VerifyInfo {
+    public String email;
+    public String code;
+
+    public VerifyInfo(String email, String code){
+        this.email = email;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/service/EmailService.java
+++ b/src/main/java/com/example/darnerdanuh/service/EmailService.java
@@ -1,0 +1,88 @@
+package com.example.darnerdanuh.service;
+
+import java.util.Random;
+
+import javax.mail.Message.RecipientType;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    final
+    JavaMailSender emailSender;
+
+    public static final String ePw = createKey();
+
+    public EmailService(JavaMailSender emailSender) {
+        this.emailSender = emailSender;
+    }
+
+    private MimeMessage createMessage(String to)throws Exception{
+        System.out.println("보내는 대상 : " + to);
+        System.out.println("인증 번호 : " + ePw);
+        MimeMessage  message = emailSender.createMimeMessage();
+
+        message.addRecipients(RecipientType.TO, to);//보내는 대상
+        message.setSubject("인증번호가 도착했습니다.");//제목
+
+        String msgg="";
+        msgg+= "<div style='margin:100px;'>";
+        msgg+= "<h1> 이메일 인증 </h1>";
+        msgg+= "<br>";
+        msgg+= "<p>아래 코드를 회원가입 창으로 돌아가 입력해주세요<p>";
+        msgg+= "<br>";
+        msgg+= "<p>감사합니다!<p>";
+        msgg+= "<br>";
+        msgg+= "<div align='center' style='border:1px solid black; font-family:verdana';>";
+        msgg+= "<h3 style='color:blue;'>회원가입 코드입니다.</h3>";
+        msgg+= "<div style='font-size:130%'>";
+        msgg+= "CODE : <strong>";
+        msgg+= ePw+"</strong><div><br/> ";
+        msgg+= "</div>";
+        message.setText(msgg, "utf-8", "html");//내용
+        message.setFrom(new InternetAddress("test@gmail.com","다너단어"));//보내는 사람
+        return message;
+    }
+    //		인증코드 만들기
+    public static String createKey() {
+        StringBuffer key = new StringBuffer();
+        Random rnd = new Random();
+
+        for (int i = 0; i < 8; i++) { // 인증코드 8자리
+            int index = rnd.nextInt(3); // 0~2 까지 랜덤
+
+            switch (index) {
+                case 0:
+                    key.append((char) ((int) (rnd.nextInt(26)) + 97));
+                    //  a~z  (ex. 1+97=98 => (char)98 = 'b')
+                    break;
+                case 1:
+                    key.append((char) ((int) (rnd.nextInt(26)) + 65));
+                    //  A~Z
+                    break;
+                case 2:
+                    key.append((rnd.nextInt(10)));
+                    // 0~9
+                    break;
+            }
+        }
+        return key.toString();
+    }
+
+    public void sendSimpleMessage(String to)throws Exception {
+        // TODO Auto-generated method stub
+        MimeMessage message = createMessage(to);
+        try{//예외처리
+            emailSender.send(message);
+        } catch(MailException es){
+            es.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/service/EmailService.java
+++ b/src/main/java/com/example/darnerdanuh/service/EmailService.java
@@ -6,22 +6,19 @@ import javax.mail.Message.RecipientType;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class EmailService {
 
-    final
-    JavaMailSender emailSender;
+    private final JavaMailSender emailSender;
 
     public static final String ePw = createKey();
-
-    public EmailService(JavaMailSender emailSender) {
-        this.emailSender = emailSender;
-    }
 
     private MimeMessage createMessage(String to)throws Exception{
         System.out.println("보내는 대상 : " + to);
@@ -78,6 +75,7 @@ public class EmailService {
     public void sendSimpleMessage(String to)throws Exception {
         // TODO Auto-generated method stub
         MimeMessage message = createMessage(to);
+
         try{//예외처리
             emailSender.send(message);
         } catch(MailException es){

--- a/src/main/java/com/example/darnerdanuh/service/JwtUserDetailsService.java
+++ b/src/main/java/com/example/darnerdanuh/service/JwtUserDetailsService.java
@@ -27,23 +27,23 @@ public class JwtUserDetailsService implements UserDetailsService {
     private MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException{
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
         Member member = memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new UsernameNotFoundException(userId));
         Set<GrantedAuthority> grantedAuthorities = new HashSet<>();
         grantedAuthorities.add(new SimpleGrantedAuthority(Role.USER.getValue()));
-        if(userId.equals("dndn2100")){
+        if (userId.equals("dndn2100")) {
             grantedAuthorities.add(new SimpleGrantedAuthority(Role.ADMIN.getValue()));
         }
 
         return new User(member.getUserId(), member.getPassword(), grantedAuthorities);
     }
 
-    public Member authenticateByUserIdAndPassword(String userId, String password){
+    public Member authenticateByUserIdAndPassword(String userId, String password) {
         Member member = memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new UsernameNotFoundException(userId));
 
-        if(!passwordEncoder.matches(password, member.getPassword())){
+        if (!passwordEncoder.matches(password, member.getPassword())) {
             throw new BadCredentialsException("Password not matched");
         }
 

--- a/src/main/java/com/example/darnerdanuh/service/JwtUserDetailsService.java
+++ b/src/main/java/com/example/darnerdanuh/service/JwtUserDetailsService.java
@@ -1,0 +1,52 @@
+package com.example.darnerdanuh.service;
+
+import com.example.darnerdanuh.domain.member.Member;
+import com.example.darnerdanuh.domain.member.MemberRepository;
+import com.example.darnerdanuh.domain.member.Role;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class JwtUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException{
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new UsernameNotFoundException(userId));
+        Set<GrantedAuthority> grantedAuthorities = new HashSet<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority(Role.USER.getValue()));
+        if(userId.equals("dndn2100")){
+            grantedAuthorities.add(new SimpleGrantedAuthority(Role.ADMIN.getValue()));
+        }
+
+        return new User(member.getUserId(), member.getPassword(), grantedAuthorities);
+    }
+
+    public Member authenticateByUserIdAndPassword(String userId, String password){
+        Member member = memberRepository.findByUserId(userId)
+                .orElseThrow(() -> new UsernameNotFoundException(userId));
+
+        if(!passwordEncoder.matches(password, member.getPassword())){
+            throw new BadCredentialsException("Password not matched");
+        }
+
+        return member;
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/service/SignUpService.java
+++ b/src/main/java/com/example/darnerdanuh/service/SignUpService.java
@@ -1,0 +1,42 @@
+package com.example.darnerdanuh.service;
+
+import com.example.darnerdanuh.domain.ResponseJson;
+import com.example.darnerdanuh.domain.member.Member;
+import com.example.darnerdanuh.domain.member.MemberDto;
+import com.example.darnerdanuh.domain.member.MemberRepository;
+import com.example.darnerdanuh.domain.member.VerifyInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpService {
+    private final MemberRepository memberRepository;
+
+    private final PasswordEncoder encode;
+    private final EmailService service;
+
+    @SneakyThrows
+    public ResponseJson signUp(MemberDto memberDto) {
+        Member member = memberRepository.save(
+                Member.builder()
+                        .email(memberDto.getEmail())
+                        .name(memberDto.getName())
+                        .password(encode.encode(memberDto.getPassword()))
+                        .userId(memberDto.getUserId())
+                        .build()
+        );
+        service.sendSimpleMessage(memberDto.getEmail());
+
+        ResponseJson json = new ResponseJson();
+        VerifyInfo info = new VerifyInfo(memberDto.getEmail(), EmailService.ePw);
+        memberRepository.save(member.verifyCodeUpdate(info.code));
+
+        System.out.println("이메일/코드 : " + info.email + " " + info.code);
+        json.setMessage("success");
+
+        return json;
+    }
+}

--- a/src/main/java/com/example/darnerdanuh/service/VerifyCodeService.java
+++ b/src/main/java/com/example/darnerdanuh/service/VerifyCodeService.java
@@ -1,0 +1,33 @@
+package com.example.darnerdanuh.service;
+
+import com.example.darnerdanuh.domain.ResponseJson;
+import com.example.darnerdanuh.domain.member.Member;
+import com.example.darnerdanuh.domain.member.MemberRepository;
+import com.example.darnerdanuh.domain.member.VerifyInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VerifyCodeService {
+    private final MemberRepository memberRepository;
+
+    public ResponseJson setVerifyCode(VerifyInfo verifyInfo) {
+        boolean isSuccess = false;
+        Member member = memberRepository.findByEmail(verifyInfo.getEmail())
+                .orElseThrow(RuntimeException::new);
+
+        System.out.println("Input : " + verifyInfo.email + " " + verifyInfo.code);
+
+        if (member.getVerifyCode().equals(verifyInfo.code)) {
+            isSuccess = true;
+            memberRepository.save(member.permittedUpdate(isSuccess));
+        }
+
+        ResponseJson json = new ResponseJson();
+        String msg = String.valueOf(isSuccess);
+        json.setMessage(msg);
+
+        return json;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
-
+spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/darner_dan_uh?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.username=root
+spring.datasource.password=1234

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/darner_dan_uh?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=1234
+spring.datasource.password=idolm@ster1
 server.error.include-stacktrace=always
 server.error.whitelabel.enabled=false
 server.error.include-binding-errors=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/darner_dan_uh?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=1234
+server.error.include-stacktrace=never
+server.error.whitelabel.enabled=false
+server.error.include-binding-errors=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/darner_dan_uh?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=1234
-server.error.include-stacktrace=never
+server.error.include-stacktrace=always
 server.error.whitelabel.enabled=false
 server.error.include-binding-errors=never

--- a/src/main/resources/mail.properties
+++ b/src/main/resources/mail.properties
@@ -1,0 +1,11 @@
+mail.smtp.auth=true
+mail.smtp.starttls.required=true
+mail.smtp.starttls.enable=true
+mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
+mail.smtp.socketFactory.fallback=false
+mail.smtp.port=465
+mail.smtp.socketFactory.port=465
+
+#admin darnerdanu
+AdminMail.id = darnerdanuh@gmail.com
+AdminMail.password = darnerdanuh1234

--- a/src/main/resources/mail.properties
+++ b/src/main/resources/mail.properties
@@ -8,4 +8,4 @@ mail.smtp.socketFactory.port=465
 
 #admin darnerdanu
 AdminMail.id = darnerdanuh@gmail.com
-AdminMail.password = darnerdanuh1234
+AdminMail.password = nkwqyuofusebvjtz


### PR DESCRIPTION
1. 이메일 인증 api 만들었음. 시간 날 때 api 명세 문서에 사용하는 법 적어두겠다
2. Member 클래스에서 각 컬럼들 설정이랑 추가된 컬럼이 있는데 변경점 확인하면 됨
3. 이메일 관련 api를 전부 서비스 클래스랑 그런걸로 분리했음. 코드 깔끔해짐.
4. Member에 @lobok.Builder 추가해서 createMember 메소드 삭제하고 걍 롬복 기능 이용하기로 함. 앞으로는 builder() 쓰셈.
5. 등등 여러가지 변경점이 있으나 엄청나게 바뀌진 않았으니 그대로 이용하면 됨.